### PR TITLE
Removing FINAL keyword from class generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>com.squareup.wire</groupId>
   <artifactId>wire</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.0.2bb</version>
 
   <inceptionYear>2013</inceptionYear>
 

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-sample</artifactId>

--- a/wire-compiler/pom.xml
+++ b/wire-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-compiler</artifactId>

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -55,7 +55,7 @@ public class WireCompilerErrorTest {
         + "}\n");
     String generatedSource = readFile("/target/com/squareup/protos/test/Simple.java");
     assertThat(generatedSource).contains(
-        "public final class Simple extends Message<Simple, Simple.Builder> {");
+        "public class Simple extends Message<Simple, Simple.Builder> {");
   }
 
   @Test public void testZeroTag() throws Exception {

--- a/wire-gson-support/pom.xml
+++ b/wire-gson-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-gson-support</artifactId>

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -17,7 +17,7 @@ import java.lang.String;
 import java.util.List;
 import okio.ByteString;
 
-public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
+public class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public static final ProtoAdapter<AllTypes> ADAPTER = ProtoAdapter.newMessageAdapter(AllTypes.class);
 
   private static final long serialVersionUID = 0L;
@@ -2796,7 +2796,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
   }
 
-  public static final class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
+  public static class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
     public static final ProtoAdapter<NestedMessage> ADAPTER = ProtoAdapter.newMessageAdapter(NestedMessage.class);
 
     private static final long serialVersionUID = 0L;

--- a/wire-java-generator/pom.xml
+++ b/wire-java-generator/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-java-generator</artifactId>

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -406,7 +406,7 @@ public final class JavaGenerator {
     ClassName builderJavaType = javaType.nestedClass("Builder");
 
     TypeSpec.Builder builder = TypeSpec.classBuilder(javaType.simpleName());
-    builder.addModifiers(PUBLIC, FINAL);
+    builder.addModifiers(PUBLIC);
 
     if (javaType.enclosingClassName() != null) {
       builder.addModifiers(STATIC);

--- a/wire-maven-plugin/pom.xml
+++ b/wire-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-maven-plugin</artifactId>

--- a/wire-runtime/pom.xml
+++ b/wire-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-runtime</artifactId>

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -19,7 +19,7 @@ import okio.ByteString;
 /**
  * Describes a message type.
  */
-public final class DescriptorProto extends Message<DescriptorProto, DescriptorProto.Builder> {
+public class DescriptorProto extends Message<DescriptorProto, DescriptorProto.Builder> {
   public static final ProtoAdapter<DescriptorProto> ADAPTER = new ProtoAdapter<DescriptorProto>(FieldEncoding.LENGTH_DELIMITED, DescriptorProto.class) {
     @Override
     public int encodedSize(DescriptorProto value) {
@@ -311,7 +311,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     }
   }
 
-  public static final class ExtensionRange extends Message<ExtensionRange, ExtensionRange.Builder> {
+  public static class ExtensionRange extends Message<ExtensionRange, ExtensionRange.Builder> {
     public static final ProtoAdapter<ExtensionRange> ADAPTER = new ProtoAdapter<ExtensionRange>(FieldEncoding.LENGTH_DELIMITED, ExtensionRange.class) {
       @Override
       public int encodedSize(ExtensionRange value) {
@@ -443,7 +443,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
    * fields or extension ranges in the same message. Reserved ranges may
    * not overlap.
    */
-  public static final class ReservedRange extends Message<ReservedRange, ReservedRange.Builder> {
+  public static class ReservedRange extends Message<ReservedRange, ReservedRange.Builder> {
     public static final ProtoAdapter<ReservedRange> ADAPTER = new ProtoAdapter<ReservedRange>(FieldEncoding.LENGTH_DELIMITED, ReservedRange.class) {
       @Override
       public int encodedSize(ReservedRange value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
@@ -18,7 +18,7 @@ import okio.ByteString;
 /**
  * Describes an enum type.
  */
-public final class EnumDescriptorProto extends Message<EnumDescriptorProto, EnumDescriptorProto.Builder> {
+public class EnumDescriptorProto extends Message<EnumDescriptorProto, EnumDescriptorProto.Builder> {
   public static final ProtoAdapter<EnumDescriptorProto> ADAPTER = new ProtoAdapter<EnumDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, EnumDescriptorProto.class) {
     @Override
     public int encodedSize(EnumDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
@@ -16,7 +16,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder> {
+public class EnumOptions extends Message<EnumOptions, EnumOptions.Builder> {
   public static final ProtoAdapter<EnumOptions> ADAPTER = new ProtoAdapter<EnumOptions>(FieldEncoding.LENGTH_DELIMITED, EnumOptions.class) {
     @Override
     public int encodedSize(EnumOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -18,7 +18,7 @@ import okio.ByteString;
 /**
  * Describes a value within an enum.
  */
-public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto, EnumValueDescriptorProto.Builder> {
+public class EnumValueDescriptorProto extends Message<EnumValueDescriptorProto, EnumValueDescriptorProto.Builder> {
   public static final ProtoAdapter<EnumValueDescriptorProto> ADAPTER = new ProtoAdapter<EnumValueDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, EnumValueDescriptorProto.class) {
     @Override
     public int encodedSize(EnumValueDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
@@ -18,7 +18,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueOptions.Builder> {
+public class EnumValueOptions extends Message<EnumValueOptions, EnumValueOptions.Builder> {
   public static final ProtoAdapter<EnumValueOptions> ADAPTER = new ProtoAdapter<EnumValueOptions>(FieldEncoding.LENGTH_DELIMITED, EnumValueOptions.class) {
     @Override
     public int encodedSize(EnumValueOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -19,7 +19,7 @@ import okio.ByteString;
 /**
  * Describes a field within a message.
  */
-public final class FieldDescriptorProto extends Message<FieldDescriptorProto, FieldDescriptorProto.Builder> {
+public class FieldDescriptorProto extends Message<FieldDescriptorProto, FieldDescriptorProto.Builder> {
   public static final ProtoAdapter<FieldDescriptorProto> ADAPTER = new ProtoAdapter<FieldDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, FieldDescriptorProto.class) {
     @Override
     public int encodedSize(FieldDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -20,7 +20,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class FieldOptions extends Message<FieldOptions, FieldOptions.Builder> {
+public class FieldOptions extends Message<FieldOptions, FieldOptions.Builder> {
   public static final ProtoAdapter<FieldOptions> ADAPTER = new ProtoAdapter<FieldOptions>(FieldEncoding.LENGTH_DELIMITED, FieldOptions.class) {
     @Override
     public int encodedSize(FieldOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -19,7 +19,7 @@ import okio.ByteString;
 /**
  * Describes a complete .proto file.
  */
-public final class FileDescriptorProto extends Message<FileDescriptorProto, FileDescriptorProto.Builder> {
+public class FileDescriptorProto extends Message<FileDescriptorProto, FileDescriptorProto.Builder> {
   public static final ProtoAdapter<FileDescriptorProto> ADAPTER = new ProtoAdapter<FileDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, FileDescriptorProto.class) {
     @Override
     public int encodedSize(FileDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
@@ -19,7 +19,7 @@ import okio.ByteString;
  * The protocol compiler can output a FileDescriptorSet containing the .proto
  * files it parses.
  */
-public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDescriptorSet.Builder> {
+public class FileDescriptorSet extends Message<FileDescriptorSet, FileDescriptorSet.Builder> {
   public static final ProtoAdapter<FileDescriptorSet> ADAPTER = new ProtoAdapter<FileDescriptorSet>(FieldEncoding.LENGTH_DELIMITED, FileDescriptorSet.class) {
     @Override
     public int encodedSize(FileDescriptorSet value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -49,7 +49,7 @@ import okio.ByteString;
  *   If this turns out to be popular, a web service will be set up
  *   to automatically assign option numbers.
  */
-public final class FileOptions extends Message<FileOptions, FileOptions.Builder> {
+public class FileOptions extends Message<FileOptions, FileOptions.Builder> {
   public static final ProtoAdapter<FileOptions> ADAPTER = new ProtoAdapter<FileOptions>(FieldEncoding.LENGTH_DELIMITED, FileOptions.class) {
     @Override
     public int encodedSize(FileOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
@@ -19,7 +19,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class MessageOptions extends Message<MessageOptions, MessageOptions.Builder> {
+public class MessageOptions extends Message<MessageOptions, MessageOptions.Builder> {
   public static final ProtoAdapter<MessageOptions> ADAPTER = new ProtoAdapter<MessageOptions>(FieldEncoding.LENGTH_DELIMITED, MessageOptions.class) {
     @Override
     public int encodedSize(MessageOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
@@ -18,7 +18,7 @@ import okio.ByteString;
 /**
  * Describes a method of a service.
  */
-public final class MethodDescriptorProto extends Message<MethodDescriptorProto, MethodDescriptorProto.Builder> {
+public class MethodDescriptorProto extends Message<MethodDescriptorProto, MethodDescriptorProto.Builder> {
   public static final ProtoAdapter<MethodDescriptorProto> ADAPTER = new ProtoAdapter<MethodDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, MethodDescriptorProto.class) {
     @Override
     public int encodedSize(MethodDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
@@ -16,7 +16,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class MethodOptions extends Message<MethodOptions, MethodOptions.Builder> {
+public class MethodOptions extends Message<MethodOptions, MethodOptions.Builder> {
   public static final ProtoAdapter<MethodOptions> ADAPTER = new ProtoAdapter<MethodOptions>(FieldEncoding.LENGTH_DELIMITED, MethodOptions.class) {
     @Override
     public int encodedSize(MethodOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
@@ -17,7 +17,7 @@ import okio.ByteString;
 /**
  * Describes a oneof.
  */
-public final class OneofDescriptorProto extends Message<OneofDescriptorProto, OneofDescriptorProto.Builder> {
+public class OneofDescriptorProto extends Message<OneofDescriptorProto, OneofDescriptorProto.Builder> {
   public static final ProtoAdapter<OneofDescriptorProto> ADAPTER = new ProtoAdapter<OneofDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, OneofDescriptorProto.class) {
     @Override
     public int encodedSize(OneofDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
@@ -18,7 +18,7 @@ import okio.ByteString;
 /**
  * Describes a service.
  */
-public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto, ServiceDescriptorProto.Builder> {
+public class ServiceDescriptorProto extends Message<ServiceDescriptorProto, ServiceDescriptorProto.Builder> {
   public static final ProtoAdapter<ServiceDescriptorProto> ADAPTER = new ProtoAdapter<ServiceDescriptorProto>(FieldEncoding.LENGTH_DELIMITED, ServiceDescriptorProto.class) {
     @Override
     public int encodedSize(ServiceDescriptorProto value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
@@ -16,7 +16,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions.Builder> {
+public class ServiceOptions extends Message<ServiceOptions, ServiceOptions.Builder> {
   public static final ProtoAdapter<ServiceOptions> ADAPTER = new ProtoAdapter<ServiceOptions>(FieldEncoding.LENGTH_DELIMITED, ServiceOptions.class) {
     @Override
     public int encodedSize(ServiceOptions value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
@@ -22,7 +22,7 @@ import okio.ByteString;
  * Encapsulates information about the original source file from which a
  * FileDescriptorProto was generated.
  */
-public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo.Builder> {
+public class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo.Builder> {
   public static final ProtoAdapter<SourceCodeInfo> ADAPTER = new ProtoAdapter<SourceCodeInfo>(FieldEncoding.LENGTH_DELIMITED, SourceCodeInfo.class) {
     @Override
     public int encodedSize(SourceCodeInfo value) {
@@ -220,7 +220,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     }
   }
 
-  public static final class Location extends Message<Location, Location.Builder> {
+  public static class Location extends Message<Location, Location.Builder> {
     public static final ProtoAdapter<Location> ADAPTER = new ProtoAdapter<Location>(FieldEncoding.LENGTH_DELIMITED, Location.class) {
       @Override
       public int encodedSize(Location value) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
@@ -26,7 +26,7 @@ import okio.ByteString;
  * or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
  * in them.
  */
-public final class UninterpretedOption extends Message<UninterpretedOption, UninterpretedOption.Builder> {
+public class UninterpretedOption extends Message<UninterpretedOption, UninterpretedOption.Builder> {
   public static final ProtoAdapter<UninterpretedOption> ADAPTER = new ProtoAdapter<UninterpretedOption>(FieldEncoding.LENGTH_DELIMITED, UninterpretedOption.class) {
     @Override
     public int encodedSize(UninterpretedOption value) {
@@ -263,7 +263,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
    * E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
    * "foo.(bar.baz).qux".
    */
-  public static final class NamePart extends Message<NamePart, NamePart.Builder> {
+  public static class NamePart extends Message<NamePart, NamePart.Builder> {
     public static final ProtoAdapter<NamePart> ADAPTER = new ProtoAdapter<NamePart>(FieldEncoding.LENGTH_DELIMITED, NamePart.class) {
       @Override
       public int encodedSize(NamePart value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Bar extends Message<Bar, Bar.Builder> {
+public class Bar extends Message<Bar, Bar.Builder> {
   public static final ProtoAdapter<Bar> ADAPTER = new ProtoAdapter<Bar>(FieldEncoding.LENGTH_DELIMITED, Bar.class) {
     @Override
     public int encodedSize(Bar value) {
@@ -94,7 +94,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
     }
   }
 
-  public static final class Baz extends Message<Baz, Baz.Builder> {
+  public static class Baz extends Message<Baz, Baz.Builder> {
     public static final ProtoAdapter<Baz> ADAPTER = new ProtoAdapter<Baz>(FieldEncoding.LENGTH_DELIMITED, Baz.class) {
       @Override
       public int encodedSize(Baz value) {
@@ -174,7 +174,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
       }
     }
 
-    public static final class Moo extends Message<Moo, Moo.Builder> {
+    public static class Moo extends Message<Moo, Moo.Builder> {
       public static final ProtoAdapter<Moo> ADAPTER = new ProtoAdapter<Moo>(FieldEncoding.LENGTH_DELIMITED, Moo.class) {
         @Override
         public int encodedSize(Moo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Foo extends Message<Foo, Foo.Builder> {
+public class Foo extends Message<Foo, Foo.Builder> {
   public static final ProtoAdapter<Foo> ADAPTER = new ProtoAdapter<Foo>(FieldEncoding.LENGTH_DELIMITED, Foo.class) {
     @Override
     public int encodedSize(Foo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Bar extends Message<Bar, Bar.Builder> {
+public class Bar extends Message<Bar, Bar.Builder> {
   public static final ProtoAdapter<Bar> ADAPTER = new ProtoAdapter<Bar>(FieldEncoding.LENGTH_DELIMITED, Bar.class) {
     @Override
     public int encodedSize(Bar value) {
@@ -94,7 +94,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
     }
   }
 
-  public static final class Baz extends Message<Baz, Baz.Builder> {
+  public static class Baz extends Message<Baz, Baz.Builder> {
     public static final ProtoAdapter<Baz> ADAPTER = new ProtoAdapter<Baz>(FieldEncoding.LENGTH_DELIMITED, Baz.class) {
       @Override
       public int encodedSize(Baz value) {
@@ -174,7 +174,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
       }
     }
 
-    public static final class Moo extends Message<Moo, Moo.Builder> {
+    public static class Moo extends Message<Moo, Moo.Builder> {
       public static final ProtoAdapter<Moo> ADAPTER = new ProtoAdapter<Moo>(FieldEncoding.LENGTH_DELIMITED, Moo.class) {
         @Override
         public int encodedSize(Moo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Foo extends Message<Foo, Foo.Builder> {
+public class Foo extends Message<Foo, Foo.Builder> {
   public static final ProtoAdapter<Foo> ADAPTER = new ProtoAdapter<Foo>(FieldEncoding.LENGTH_DELIMITED, Foo.class) {
     @Override
     public int encodedSize(Foo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest, HeresAllTheDataRequest.Builder> {
+public class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest, HeresAllTheDataRequest.Builder> {
   public static final ProtoAdapter<HeresAllTheDataRequest> ADAPTER = new ProtoAdapter<HeresAllTheDataRequest>(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataRequest.class) {
     @Override
     public int encodedSize(HeresAllTheDataRequest value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class HeresAllTheDataResponse extends Message<HeresAllTheDataResponse, HeresAllTheDataResponse.Builder> {
+public class HeresAllTheDataResponse extends Message<HeresAllTheDataResponse, HeresAllTheDataResponse.Builder> {
   public static final ProtoAdapter<HeresAllTheDataResponse> ADAPTER = new ProtoAdapter<HeresAllTheDataResponse>(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataResponse.class) {
     @Override
     public int encodedSize(HeresAllTheDataResponse value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequest.Builder> {
+public class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequest.Builder> {
   public static final ProtoAdapter<LetsDataRequest> ADAPTER = new ProtoAdapter<LetsDataRequest>(FieldEncoding.LENGTH_DELIMITED, LetsDataRequest.class) {
     @Override
     public int encodedSize(LetsDataRequest value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataResponse.Builder> {
+public class LetsDataResponse extends Message<LetsDataResponse, LetsDataResponse.Builder> {
   public static final ProtoAdapter<LetsDataResponse> ADAPTER = new ProtoAdapter<LetsDataResponse>(FieldEncoding.LENGTH_DELIMITED, LetsDataResponse.class) {
     @Override
     public int encodedSize(LetsDataResponse value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class SendDataRequest extends Message<SendDataRequest, SendDataRequest.Builder> {
+public class SendDataRequest extends Message<SendDataRequest, SendDataRequest.Builder> {
   public static final ProtoAdapter<SendDataRequest> ADAPTER = new ProtoAdapter<SendDataRequest>(FieldEncoding.LENGTH_DELIMITED, SendDataRequest.class) {
     @Override
     public int encodedSize(SendDataRequest value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class SendDataResponse extends Message<SendDataResponse, SendDataResponse.Builder> {
+public class SendDataResponse extends Message<SendDataResponse, SendDataResponse.Builder> {
   public static final ProtoAdapter<SendDataResponse> ADAPTER = new ProtoAdapter<SendDataResponse>(FieldEncoding.LENGTH_DELIMITED, SendDataResponse.class) {
     @Override
     public int encodedSize(SendDataResponse value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class ChildPackage extends Message<ChildPackage, ChildPackage.Builder> {
+public class ChildPackage extends Message<ChildPackage, ChildPackage.Builder> {
   public static final ProtoAdapter<ChildPackage> ADAPTER = new ProtoAdapter<ChildPackage>(FieldEncoding.LENGTH_DELIMITED, ChildPackage.class) {
     @Override
     public int encodedSize(ChildPackage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -16,7 +16,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class RepeatedAndPacked extends Message<RepeatedAndPacked, RepeatedAndPacked.Builder> {
+public class RepeatedAndPacked extends Message<RepeatedAndPacked, RepeatedAndPacked.Builder> {
   public static final ProtoAdapter<RepeatedAndPacked> ADAPTER = new ProtoAdapter<RepeatedAndPacked>(FieldEncoding.LENGTH_DELIMITED, RepeatedAndPacked.class) {
     @Override
     public int encodedSize(RepeatedAndPacked value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -21,7 +21,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
+public class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public static final ProtoAdapter<AllTypes> ADAPTER = new ProtoAdapter<AllTypes>(FieldEncoding.LENGTH_DELIMITED, AllTypes.class) {
     @Override
     public int encodedSize(AllTypes value) {
@@ -2822,7 +2822,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
   }
 
-  public static final class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
+  public static class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
     public static final ProtoAdapter<NestedMessage> ADAPTER = new ProtoAdapter<NestedMessage>(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class) {
       @Override
       public int encodedSize(NestedMessage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
@@ -17,7 +17,7 @@ import java.lang.String;
 import java.util.List;
 import okio.ByteString;
 
-public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
+public class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public static final ProtoAdapter<AllTypes> ADAPTER = ProtoAdapter.newMessageAdapter(AllTypes.class);
 
   private static final long serialVersionUID = 0L;
@@ -2796,7 +2796,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
   }
 
-  public static final class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
+  public static class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
     public static final ProtoAdapter<NestedMessage> ADAPTER = ProtoAdapter.newMessageAdapter(NestedMessage.class);
 
     private static final long serialVersionUID = 0L;

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import okio.ByteString;
 
-public final class FooBar extends Message<FooBar, FooBar.Builder> {
+public class FooBar extends Message<FooBar, FooBar.Builder> {
   public static final ProtoAdapter<FooBar> ADAPTER = new ProtoAdapter<FooBar>(FieldEncoding.LENGTH_DELIMITED, FooBar.class) {
     @Override
     public int encodedSize(FooBar value) {
@@ -349,7 +349,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
   }
 
-  public static final class Nested extends Message<Nested, Nested.Builder> {
+  public static class Nested extends Message<Nested, Nested.Builder> {
     public static final ProtoAdapter<Nested> ADAPTER = new ProtoAdapter<Nested>(FieldEncoding.LENGTH_DELIMITED, Nested.class) {
       @Override
       public int encodedSize(Nested value) {
@@ -464,7 +464,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
   }
 
-  public static final class More extends Message<More, More.Builder> {
+  public static class More extends Message<More, More.Builder> {
     public static final ProtoAdapter<More> ADAPTER = new ProtoAdapter<More>(FieldEncoding.LENGTH_DELIMITED, More.class) {
       @Override
       public int encodedSize(More value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -20,7 +20,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class FooBar extends Message<FooBar, FooBar.Builder> {
+public class FooBar extends Message<FooBar, FooBar.Builder> {
   public static final ProtoAdapter<FooBar> ADAPTER = new ProtoAdapter<FooBar>(FieldEncoding.LENGTH_DELIMITED, FooBar.class) {
     @Override
     public int encodedSize(FooBar value) {
@@ -299,7 +299,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
   }
 
-  public static final class Nested extends Message<Nested, Nested.Builder> {
+  public static class Nested extends Message<Nested, Nested.Builder> {
     public static final ProtoAdapter<Nested> ADAPTER = new ProtoAdapter<Nested>(FieldEncoding.LENGTH_DELIMITED, Nested.class) {
       @Override
       public int encodedSize(Nested value) {
@@ -414,7 +414,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
   }
 
-  public static final class More extends Message<More, More.Builder> {
+  public static class More extends Message<More, More.Builder> {
     public static final ProtoAdapter<More> ADAPTER = new ProtoAdapter<More>(FieldEncoding.LENGTH_DELIMITED, More.class) {
       @Override
       public int encodedSize(More value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -17,7 +17,7 @@ import java.lang.StringBuilder;
 import java.util.Arrays;
 import okio.ByteString;
 
-public final class MessageWithOptions extends Message<MessageWithOptions, MessageWithOptions.Builder> {
+public class MessageWithOptions extends Message<MessageWithOptions, MessageWithOptions.Builder> {
   public static final ProtoAdapter<MessageWithOptions> ADAPTER = new ProtoAdapter<MessageWithOptions>(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class) {
     @Override
     public int encodedSize(MessageWithOptions value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class MessageWithOptions extends Message<MessageWithOptions, MessageWithOptions.Builder> {
+public class MessageWithOptions extends Message<MessageWithOptions, MessageWithOptions.Builder> {
   public static final ProtoAdapter<MessageWithOptions> ADAPTER = new ProtoAdapter<MessageWithOptions>(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class) {
     @Override
     public int encodedSize(MessageWithOptions value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class NoFields extends Message<NoFields, NoFields.Builder> {
+public class NoFields extends Message<NoFields, NoFields.Builder> {
   public static final ProtoAdapter<NoFields> ADAPTER = new ProtoAdapter<NoFields>(FieldEncoding.LENGTH_DELIMITED, NoFields.class) {
     @Override
     public int encodedSize(NoFields value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class OneBytesField extends Message<OneBytesField, OneBytesField.Builder> {
+public class OneBytesField extends Message<OneBytesField, OneBytesField.Builder> {
   public static final ProtoAdapter<OneBytesField> ADAPTER = new ProtoAdapter<OneBytesField>(FieldEncoding.LENGTH_DELIMITED, OneBytesField.class) {
     @Override
     public int encodedSize(OneBytesField value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class OneField extends Message<OneField, OneField.Builder> {
+public class OneField extends Message<OneField, OneField.Builder> {
   public static final ProtoAdapter<OneField> ADAPTER = new ProtoAdapter<OneField>(FieldEncoding.LENGTH_DELIMITED, OneField.class) {
     @Override
     public int encodedSize(OneField value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Recursive extends Message<Recursive, Recursive.Builder> {
+public class Recursive extends Message<Recursive, Recursive.Builder> {
   public static final ProtoAdapter<Recursive> ADAPTER = new ProtoAdapter<Recursive>(FieldEncoding.LENGTH_DELIMITED, Recursive.class) {
     @Override
     public int encodedSize(Recursive value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage.Builder> {
+public class ForeignMessage extends Message<ForeignMessage, ForeignMessage.Builder> {
   public static final ProtoAdapter<ForeignMessage> ADAPTER = new ProtoAdapter<ForeignMessage>(FieldEncoding.LENGTH_DELIMITED, ForeignMessage.class) {
     @Override
     public int encodedSize(ForeignMessage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -13,7 +13,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Message extends com.squareup.wire.Message<Message, Message.Builder> {
+public class Message extends com.squareup.wire.Message<Message, Message.Builder> {
   public static final ProtoAdapter<Message> ADAPTER = new ProtoAdapter<Message>(FieldEncoding.LENGTH_DELIMITED, Message.class) {
     @Override
     public int encodedSize(Message value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Foo extends Message<Foo, Foo.Builder> {
+public class Foo extends Message<Foo, Foo.Builder> {
   public static final ProtoAdapter<Foo> ADAPTER = new ProtoAdapter<Foo>(FieldEncoding.LENGTH_DELIMITED, Foo.class) {
     @Override
     public int encodedSize(Foo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class OneExtension extends Message<OneExtension, OneExtension.Builder> {
+public class OneExtension extends Message<OneExtension, OneExtension.Builder> {
   public static final ProtoAdapter<OneExtension> ADAPTER = new ProtoAdapter<OneExtension>(FieldEncoding.LENGTH_DELIMITED, OneExtension.class) {
     @Override
     public int encodedSize(OneExtension value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Builder> {
+public class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Builder> {
   public static final ProtoAdapter<OneOfMessage> ADAPTER = new ProtoAdapter<OneOfMessage>(FieldEncoding.LENGTH_DELIMITED, OneOfMessage.class) {
     @Override
     public int encodedSize(OneOfMessage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -17,7 +17,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class Person extends Message<Person, Person.Builder> {
+public class Person extends Message<Person, Person.Builder> {
   public static final ProtoAdapter<Person> ADAPTER = new ProtoAdapter<Person>(FieldEncoding.LENGTH_DELIMITED, Person.class) {
     @Override
     public int encodedSize(Person value) {
@@ -247,7 +247,7 @@ public final class Person extends Message<Person, Person.Builder> {
     }
   }
 
-  public static final class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> {
+  public static class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> {
     public static final ProtoAdapter<PhoneNumber> ADAPTER = new ProtoAdapter<PhoneNumber>(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class) {
       @Override
       public int encodedSize(PhoneNumber value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -20,7 +20,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class Person extends Message<Person, Person.Builder> implements Parcelable {
+public class Person extends Message<Person, Person.Builder> implements Parcelable {
   public static final ProtoAdapter<Person> ADAPTER = new ProtoAdapter<Person>(FieldEncoding.LENGTH_DELIMITED, Person.class) {
     @Override
     public int encodedSize(Person value) {
@@ -276,7 +276,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     }
   }
 
-  public static final class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> implements Parcelable {
+  public static class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> implements Parcelable {
     public static final ProtoAdapter<PhoneNumber> ADAPTER = new ProtoAdapter<PhoneNumber>(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class) {
       @Override
       public int encodedSize(PhoneNumber value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder> {
+public class NotRedacted extends Message<NotRedacted, NotRedacted.Builder> {
   public static final ProtoAdapter<NotRedacted> ADAPTER = new ProtoAdapter<NotRedacted>(FieldEncoding.LENGTH_DELIMITED, NotRedacted.class) {
     @Override
     public int encodedSize(NotRedacted value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Redacted extends Message<Redacted, Redacted.Builder> {
+public class Redacted extends Message<Redacted, Redacted.Builder> {
   public static final ProtoAdapter<Redacted> ADAPTER = new ProtoAdapter<Redacted>(FieldEncoding.LENGTH_DELIMITED, Redacted.class) {
     @Override
     public int encodedSize(Redacted value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class RedactedChild extends Message<RedactedChild, RedactedChild.Builder> {
+public class RedactedChild extends Message<RedactedChild, RedactedChild.Builder> {
   public static final ProtoAdapter<RedactedChild> ADAPTER = new ProtoAdapter<RedactedChild>(FieldEncoding.LENGTH_DELIMITED, RedactedChild.class) {
     @Override
     public int encodedSize(RedactedChild value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA.Builder> {
+public class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA.Builder> {
   public static final ProtoAdapter<RedactedCycleA> ADAPTER = new ProtoAdapter<RedactedCycleA>(FieldEncoding.LENGTH_DELIMITED, RedactedCycleA.class) {
     @Override
     public int encodedSize(RedactedCycleA value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB.Builder> {
+public class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB.Builder> {
   public static final ProtoAdapter<RedactedCycleB> ADAPTER = new ProtoAdapter<RedactedCycleB>(FieldEncoding.LENGTH_DELIMITED, RedactedCycleB.class) {
     @Override
     public int encodedSize(RedactedCycleB value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class RedactedExtension extends Message<RedactedExtension, RedactedExtension.Builder> {
+public class RedactedExtension extends Message<RedactedExtension, RedactedExtension.Builder> {
   public static final ProtoAdapter<RedactedExtension> ADAPTER = new ProtoAdapter<RedactedExtension>(FieldEncoding.LENGTH_DELIMITED, RedactedExtension.class) {
     @Override
     public int encodedSize(RedactedExtension value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import okio.ByteString;
 
-public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRepeated.Builder> {
+public class RedactedRepeated extends Message<RedactedRepeated, RedactedRepeated.Builder> {
   public static final ProtoAdapter<RedactedRepeated> ADAPTER = new ProtoAdapter<RedactedRepeated>(FieldEncoding.LENGTH_DELIMITED, RedactedRepeated.class) {
     @Override
     public int encodedSize(RedactedRepeated value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -16,7 +16,7 @@ import java.lang.StringBuilder;
 import java.lang.UnsupportedOperationException;
 import okio.ByteString;
 
-public final class RedactedRequired extends Message<RedactedRequired, RedactedRequired.Builder> {
+public class RedactedRequired extends Message<RedactedRequired, RedactedRequired.Builder> {
   public static final ProtoAdapter<RedactedRequired> ADAPTER = new ProtoAdapter<RedactedRequired>(FieldEncoding.LENGTH_DELIMITED, RedactedRequired.class) {
     @Override
     public int encodedSize(RedactedRequired value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
@@ -29,7 +29,7 @@ import okio.ByteString;
  *
  * I -> nothing
  */
-public final class A extends Message<A, A.Builder> {
+public class A extends Message<A, A.Builder> {
   public static final ProtoAdapter<A> ADAPTER = new ProtoAdapter<A>(FieldEncoding.LENGTH_DELIMITED, A.class) {
     @Override
     public int encodedSize(A value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
@@ -29,7 +29,7 @@ import okio.ByteString;
  *
  * I -> nothing
  */
-public final class A extends Message<A, A.Builder> {
+public class A extends Message<A, A.Builder> {
   public static final ProtoAdapter<A> ADAPTER = new ProtoAdapter<A>(FieldEncoding.LENGTH_DELIMITED, A.class) {
     @Override
     public int encodedSize(A value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class B extends Message<B, B.Builder> {
+public class B extends Message<B, B.Builder> {
   public static final ProtoAdapter<B> ADAPTER = new ProtoAdapter<B>(FieldEncoding.LENGTH_DELIMITED, B.class) {
     @Override
     public int encodedSize(B value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class C extends Message<C, C.Builder> {
+public class C extends Message<C, C.Builder> {
   public static final ProtoAdapter<C> ADAPTER = new ProtoAdapter<C>(FieldEncoding.LENGTH_DELIMITED, C.class) {
     @Override
     public int encodedSize(C value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class D extends Message<D, D.Builder> {
+public class D extends Message<D, D.Builder> {
   public static final ProtoAdapter<D> ADAPTER = new ProtoAdapter<D>(FieldEncoding.LENGTH_DELIMITED, D.class) {
     @Override
     public int encodedSize(D value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class D extends Message<D, D.Builder> {
+public class D extends Message<D, D.Builder> {
   public static final ProtoAdapter<D> ADAPTER = new ProtoAdapter<D>(FieldEncoding.LENGTH_DELIMITED, D.class) {
     @Override
     public int encodedSize(D value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class E extends Message<E, E.Builder> {
+public class E extends Message<E, E.Builder> {
   public static final ProtoAdapter<E> ADAPTER = new ProtoAdapter<E>(FieldEncoding.LENGTH_DELIMITED, E.class) {
     @Override
     public int encodedSize(E value) {
@@ -147,7 +147,7 @@ public final class E extends Message<E, E.Builder> {
     }
   }
 
-  public static final class F extends Message<F, F.Builder> {
+  public static class F extends Message<F, F.Builder> {
     public static final ProtoAdapter<F> ADAPTER = new ProtoAdapter<F>(FieldEncoding.LENGTH_DELIMITED, F.class) {
       @Override
       public int encodedSize(F value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class H extends Message<H, H.Builder> {
+public class H extends Message<H, H.Builder> {
   public static final ProtoAdapter<H> ADAPTER = new ProtoAdapter<H>(FieldEncoding.LENGTH_DELIMITED, H.class) {
     @Override
     public int encodedSize(H value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class I extends Message<I, I.Builder> {
+public class I extends Message<I, I.Builder> {
   public static final ProtoAdapter<I> ADAPTER = new ProtoAdapter<I>(FieldEncoding.LENGTH_DELIMITED, I.class) {
     @Override
     public int encodedSize(I value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class J extends Message<J, J.Builder> {
+public class J extends Message<J, J.Builder> {
   public static final ProtoAdapter<J> ADAPTER = new ProtoAdapter<J>(FieldEncoding.LENGTH_DELIMITED, J.class) {
     @Override
     public int encodedSize(J value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class K extends Message<K, K.Builder> {
+public class K extends Message<K, K.Builder> {
   public static final ProtoAdapter<K> ADAPTER = new ProtoAdapter<K>(FieldEncoding.LENGTH_DELIMITED, K.class) {
     @Override
     public int encodedSize(K value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/TheRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/TheRequest.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class TheRequest extends Message<TheRequest, TheRequest.Builder> {
+public class TheRequest extends Message<TheRequest, TheRequest.Builder> {
   public static final ProtoAdapter<TheRequest> ADAPTER = new ProtoAdapter<TheRequest>(FieldEncoding.LENGTH_DELIMITED, TheRequest.class) {
     @Override
     public int encodedSize(TheRequest value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/TheResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/TheResponse.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class TheResponse extends Message<TheResponse, TheResponse.Builder> {
+public class TheResponse extends Message<TheResponse, TheResponse.Builder> {
   public static final ProtoAdapter<TheResponse> ADAPTER = new ProtoAdapter<TheResponse>(FieldEncoding.LENGTH_DELIMITED, TheResponse.class) {
     @Override
     public int encodedSize(TheResponse value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
@@ -14,7 +14,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class UnnecessaryResponse extends Message<UnnecessaryResponse, UnnecessaryResponse.Builder> {
+public class UnnecessaryResponse extends Message<UnnecessaryResponse, UnnecessaryResponse.Builder> {
   public static final ProtoAdapter<UnnecessaryResponse> ADAPTER = new ProtoAdapter<UnnecessaryResponse>(FieldEncoding.LENGTH_DELIMITED, UnnecessaryResponse.class) {
     @Override
     public int encodedSize(UnnecessaryResponse value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -17,7 +17,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class ExternalMessage extends Message<ExternalMessage, ExternalMessage.Builder> {
+public class ExternalMessage extends Message<ExternalMessage, ExternalMessage.Builder> {
   public static final ProtoAdapter<ExternalMessage> ADAPTER = new ProtoAdapter<ExternalMessage>(FieldEncoding.LENGTH_DELIMITED, ExternalMessage.class) {
     @Override
     public int encodedSize(ExternalMessage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -25,7 +25,7 @@ import okio.ByteString;
 /**
  * A message for testing.
  */
-public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Builder> {
+public class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Builder> {
   public static final ProtoAdapter<SimpleMessage> ADAPTER = new ProtoAdapter<SimpleMessage>(FieldEncoding.LENGTH_DELIMITED, SimpleMessage.class) {
     @Override
     public int encodedSize(SimpleMessage value) {
@@ -433,7 +433,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     }
   }
 
-  public static final class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
+  public static class NestedMessage extends Message<NestedMessage, NestedMessage.Builder> {
     public static final ProtoAdapter<NestedMessage> ADAPTER = new ProtoAdapter<NestedMessage>(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class) {
       @Override
       public int encodedSize(NestedMessage value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Bar extends Message<Bar, Bar.Builder> {
+public class Bar extends Message<Bar, Bar.Builder> {
   public static final ProtoAdapter<Bar> ADAPTER = new ProtoAdapter<Bar>(FieldEncoding.LENGTH_DELIMITED, Bar.class) {
     @Override
     public int encodedSize(Bar value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -15,7 +15,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class Bars extends Message<Bars, Bars.Builder> {
+public class Bars extends Message<Bars, Bars.Builder> {
   public static final ProtoAdapter<Bars> ADAPTER = new ProtoAdapter<Bars>(FieldEncoding.LENGTH_DELIMITED, Bars.class) {
     @Override
     public int encodedSize(Bars value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class Foo extends Message<Foo, Foo.Builder> {
+public class Foo extends Message<Foo, Foo.Builder> {
   public static final ProtoAdapter<Foo> ADAPTER = new ProtoAdapter<Foo>(FieldEncoding.LENGTH_DELIMITED, Foo.class) {
     @Override
     public int encodedSize(Foo value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -15,7 +15,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class Foos extends Message<Foos, Foos.Builder> {
+public class Foos extends Message<Foos, Foos.Builder> {
   public static final ProtoAdapter<Foos> ADAPTER = new ProtoAdapter<Foos>(FieldEncoding.LENGTH_DELIMITED, Foos.class) {
     @Override
     public int encodedSize(Foos value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
+public class VersionOne extends Message<VersionOne, VersionOne.Builder> {
   public static final ProtoAdapter<VersionOne> ADAPTER = new ProtoAdapter<VersionOne>(FieldEncoding.LENGTH_DELIMITED, VersionOne.class) {
     @Override
     public int encodedSize(VersionOne value) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -17,7 +17,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
+public class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
   public static final ProtoAdapter<VersionTwo> ADAPTER = new ProtoAdapter<VersionTwo>(FieldEncoding.LENGTH_DELIMITED, VersionTwo.class) {
     @Override
     public int encodedSize(VersionTwo value) {

--- a/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -15,7 +15,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import okio.ByteString;
 
-public final class CollisionSubject extends Message<CollisionSubject, CollisionSubject.Builder> {
+public class CollisionSubject extends Message<CollisionSubject, CollisionSubject.Builder> {
   public static final ProtoAdapter<CollisionSubject> ADAPTER = new ProtoAdapter<CollisionSubject>(FieldEncoding.LENGTH_DELIMITED, CollisionSubject.class) {
     @Override
     public int encodedSize(CollisionSubject value) {

--- a/wire-schema/pom.xml
+++ b/wire-schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.wire</groupId>
     <artifactId>wire</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2bb</version>
   </parent>
 
   <artifactId>wire-schema</artifactId>


### PR DESCRIPTION
- Updating version for internal release. 
- Removing final keyword from generated classes. 
- Updating tests to reflect this change
